### PR TITLE
[UPDATE] Update CMU 15-418 course website and recordings

### DIFF
--- a/docs/并行与分布式系统/CS149.md
+++ b/docs/并行与分布式系统/CS149.md
@@ -14,8 +14,8 @@
 
 ## 课程资源
 
-- 课程网站：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
-- 课程视频：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/lectures), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
+- 课程网站：[CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
+- 课程视频：[CMU15418](https://www.bilibili.com/video/BV1qT411g7n9/?vd_source=8203c64d4bd9585209745df0d3b001f2), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
 - 课程教材：无
 - 课程作业：<https://gfxcourses.stanford.edu/cs149/fall21>，5 个编程作业
 

--- a/docs/并行与分布式系统/CS149.md
+++ b/docs/并行与分布式系统/CS149.md
@@ -15,7 +15,7 @@
 ## 课程资源
 
 - 课程网站：[CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
-- 课程视频：[CMU15418](https://www.bilibili.com/video/BV1qT411g7n9/?vd_source=8203c64d4bd9585209745df0d3b001f2), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
+- 课程视频：[CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/schedule.html), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
 - 课程教材：无
 - 课程作业：<https://gfxcourses.stanford.edu/cs149/fall21>，5 个编程作业
 


### PR DESCRIPTION
Update CMU 15-418 course website and recordings

Problem: The previous CMU 15-418 course website and recordings are no longer accessible, and the latest videos are only available to CMU students.
![image](https://github.com/user-attachments/assets/0e19e1fc-4334-4df0-addf-a2e3f6af164f)

Update: They have now been updated to the [sp18 version course website](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html) and the corresponding [videos](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/schedule.html), so that everyone can access and learn.