### PR TITLE
Synchronize CS149.en.md with changes made to CS149.md

### DIFF
--- a/docs/并行与分布式系统/CS149.en.md
+++ b/docs/并行与分布式系统/CS149.en.md
@@ -14,8 +14,8 @@ The goal of this course is to provide a deep understanding of the fundamental pr
 
 ## Resources
 
-- Course Website: [CMU15418](http://15418.courses.cs.cmu.edu/spring2016/), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
-- Recordings: [CMU15418](http://15418.courses.cs.cmu.edu/spring2016/lectures), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
+- Course Website: [CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
+- Recordings: [CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
 - Textbook: None
 - Assignments: <https://gfxcourses.stanford.edu/cs149/fall21>, 5 assignments.
 


### PR DESCRIPTION
Synchronize the changes between Chinese document and English document
Problem: The course website and recordings of CS15445 in [CS149.en.md](https://csdiy.wiki/en/%E5%B9%B6%E8%A1%8C%E4%B8%8E%E5%88%86%E5%B8%83%E5%BC%8F%E7%B3%BB%E7%BB%9F/CS149/#resources) is no longer accessible,  need to sync with [CS149.md](https://csdiy.wiki/%E5%B9%B6%E8%A1%8C%E4%B8%8E%E5%88%86%E5%B8%83%E5%BC%8F%E7%B3%BB%E7%BB%9F/CS149/#_2)
The Chinese version document:
<img width="1647" height="612" alt="c1441c46d687d748737940f79db684a5" src="https://github.com/user-attachments/assets/260b4a8c-38fa-4163-90d9-06a7476bcf7b" />
The English version document: 
<img width="1578" height="612" alt="8429718f5f7ed14b94685b0dab3ba1b0" src="https://github.com/user-attachments/assets/9ea1d0f0-69f7-4149-9394-250c0a6590b8" />
